### PR TITLE
The requested module 'vite' does not provide an export named 'default'

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ import { createRequire } from 'module'
 import path from 'path'
 import { execa } from 'execa'
 import { program } from 'commander'
-import vite from 'vite'
-const { build, preview, createServer } = vite
+import { build, preview, createServer } from 'vite'
 
 program
   .name('vite-e2e-cypress')


### PR DESCRIPTION
Attempting to use this playing with Vite 3 results in an "The requested module 'vite' does not provide an export named 'default'" error being produced. This will resolve that error.